### PR TITLE
fix(opt): increase spark sub-task max failures

### DIFF
--- a/local-test/config.yaml
+++ b/local-test/config.yaml
@@ -175,7 +175,7 @@ containers:
       # Number of retries by spark = spark-conf.spark.task.maxFailures - 1
       spark-conf.spark.executor.maxNumFailures: "2147483647"
       spark-conf.spark.executor.failuresValidityInterval: "10ms"
-      spark-conf.spark.task.maxFailures: "4"
+      spark-conf.spark.task.maxFailures: "2"
       # AWS/MinIO credentials for S3FileIO (Spark optimizer pods need these)
       spark-conf.spark.kubernetes.driver.secretKeyRef.AWS_ACCESS_KEY_ID: "fusion-s3-credentials:access-key-id"
       spark-conf.spark.kubernetes.driver.secretKeyRef.AWS_SECRET_ACCESS_KEY: "fusion-s3-credentials:secret-access-key"


### PR DESCRIPTION
## Description

Initially, Spark used to retry each sub-task 3 more times in case the executor fails (e.g., because of OOM). Reducing that default value to `2` now. 