### PR TITLE
fix: cache snapshots

### DIFF
--- a/amoro-ams/src/main/java/org/apache/amoro/server/table/DefaultTableRuntime.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/table/DefaultTableRuntime.java
@@ -477,16 +477,6 @@ public class DefaultTableRuntime extends AbstractTableRuntime
       store()
           .begin()
           .updateStatusCode(code -> OptimizingStatus.IDLE.getCode())
-          .updateState(
-              OPTIMIZING_STATE_KEY,
-              state -> {
-                state.setLastOptimizedSnapshotId(state.getCurrentSnapshotId());
-                state.setLastOptimizedChangeSnapshotId(state.getCurrentChangeSnapshotId());
-                if (cronType != null) {
-                  state.setLastOptimizingType(cronType.name());
-                }
-                return state;
-              })
           .updateState(PENDING_INPUT_KEY, any -> new AbstractOptimizingEvaluator.PendingInput())
           .commit();
       this.pendingCronType = null;

--- a/amoro-format-iceberg/src/main/java/org/apache/amoro/optimizing/plan/CommonPartitionEvaluator.java
+++ b/amoro-format-iceberg/src/main/java/org/apache/amoro/optimizing/plan/CommonPartitionEvaluator.java
@@ -409,8 +409,12 @@ public class CommonPartitionEvaluator implements PartitionEvaluator {
 
   public boolean isMinorNecessary() {
     int smallFileCount = fragmentFileCount + equalityDeleteFileCount;
+    LOG.warn("ASHI: isMinorNecessary partition={} fragmentFileCount={} equalityDeleteFileCount={} smallFileCount={} minorLeastFileCount={} reachMinorInterval={} combinePosSegmentFileCount={}",
+    getPartition(), fragmentFileCount, equalityDeleteFileCount,
+    fragmentFileCount + equalityDeleteFileCount, config.getMinorLeastFileCount(),
+    reachMinorInterval(), combinePosSegmentFileCount);
     return smallFileCount >= config.getMinorLeastFileCount()
-        || (smallFileCount > 1 && reachMinorInterval())
+        || (smallFileCount > 0 && reachMinorInterval())
         || combinePosSegmentFileCount > 0;
   }
 

--- a/amoro-format-iceberg/src/main/java/org/apache/amoro/optimizing/plan/CommonPartitionEvaluator.java
+++ b/amoro-format-iceberg/src/main/java/org/apache/amoro/optimizing/plan/CommonPartitionEvaluator.java
@@ -409,10 +409,6 @@ public class CommonPartitionEvaluator implements PartitionEvaluator {
 
   public boolean isMinorNecessary() {
     int smallFileCount = fragmentFileCount + equalityDeleteFileCount;
-    LOG.warn("ASHI: isMinorNecessary partition={} fragmentFileCount={} equalityDeleteFileCount={} smallFileCount={} minorLeastFileCount={} reachMinorInterval={} combinePosSegmentFileCount={}",
-    getPartition(), fragmentFileCount, equalityDeleteFileCount,
-    fragmentFileCount + equalityDeleteFileCount, config.getMinorLeastFileCount(),
-    reachMinorInterval(), combinePosSegmentFileCount);
     return smallFileCount >= config.getMinorLeastFileCount()
         || (smallFileCount > 0 && reachMinorInterval())
         || combinePosSegmentFileCount > 0;


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://amoro.apache.org/how-to-contribute/
  2. If the PR is related to an issue in https://github.com/apache/amoro/issues, add '[AMORO-XXXX]' in your PR title, e.g., '[AMORO-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][AMORO-XXXX] Your PR title ...'.
-->

## Why are the changes needed?
When the number of equality delete files is less than 2, the minor optimization is not considered necessary and skipped, even when the cron is fired.
With this change, in a case where the cron for minor has been fired and there is at least one delete file, the optimization will be marked as necessary and proceed for optimization

## Brief change log
- CommonPartitionEvaluator: isMinorNecessary() 
- A change of value from 1 to 0 in the return expression (bool)

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (yes / no) : NO
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented): not applicable
