### PR TITLE
fix(dist): package prometheus reporter jar in release-bin assembly

### DIFF
--- a/dist/src/main/assemblies/release-bin.xml
+++ b/dist/src/main/assemblies/release-bin.xml
@@ -14,6 +14,8 @@
   ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
+  ~
+  ~ Modified by Datazip Inc. in 2026
   -->
 <assembly
         xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0"

--- a/dist/src/main/assemblies/release-bin.xml
+++ b/dist/src/main/assemblies/release-bin.xml
@@ -29,6 +29,14 @@
 
     <files>
         <file>
+            <source>
+                ../amoro-metrics/amoro-metrics-prometheus/target/amoro-metrics-prometheus-${project.version}-jar-with-dependencies.jar
+            </source>
+            <outputDirectory>plugin/metric-reporters</outputDirectory>
+            <destName>prometheus-reporter.jar</destName>
+            <fileMode>0644</fileMode>
+        </file>
+        <file>
             <source>../amoro-ams/target/amoro-ams-${project.version}.jar</source>
             <outputDirectory>lib/</outputDirectory>
             <destName>amoro-ams-${project.version}.jar</destName>


### PR DESCRIPTION
## Why are the changes needed?

Enabling the Prometheus exporter on the `olakego/fusion` image kills AMS at boot:

```
org.apache.amoro.exception.LoadingPluginException: Cannot find an implement class for the plugin:prometheus-exporter
	at org.apache.amoro.server.manager.AbstractPluginManager.lambda$install$1(AbstractPluginManager.java:116)
	at org.apache.amoro.server.manager.MetricManager.initialize(MetricManager.java:66)
	at org.apache.amoro.server.AmoroServiceContainer.startRestServices(AmoroServiceContainer.java:203)
...
AMS service is shutting down...
```

Closes #23

## Brief change log

Added the prometheus reporter jar to `release-bin.xml`, matching the entry already in `bin.xml`.

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

### Steps used for testing

- After building the tarball, built the docker image locally
- Mounted the following file over `/usr/local/amoro/conf/plugins/metric-reporters.yaml`
```yaml
metric-reporters:
  - name: prometheus-exporter
    enabled: true
    properties:
      port: 7001
```
- Prometheus metrics endpoint
```
$ curl -s localhost:7001/metrics | head -20
# HELP amoro_ams_jvm_garbage_collector_time The time of the JVM's Garbage Collector
# TYPE amoro_ams_jvm_garbage_collector_time gauge
amoro_ams_jvm_garbage_collector_time{garbage_collector="G1 Young Generation",} 16.0
amoro_ams_jvm_garbage_collector_time{garbage_collector="G1 Old Generation",} 0.0
# HELP amoro_ams_ha_state The HA state of the AMS
# TYPE amoro_ams_ha_state gauge
amoro_ams_ha_state{service_state="127.0.0.1",} 2.0
# HELP amoro_ams_jvm_memory_heap_used The amount of heap memory currently used (in bytes) by the AMS
# TYPE amoro_ams_jvm_memory_heap_used gauge
amoro_ams_jvm_memory_heap_used 1.95360072E8
# HELP amoro_ams_jvm_cpu_load The recent CPU usage of the AMS
# TYPE amoro_ams_jvm_cpu_load gauge
amoro_ams_jvm_cpu_load 0.0
# HELP amoro_ams_jvm_memory_heap_committed The amount of memory in the heap that is committed for the JVM to use (in bytes)
# TYPE amoro_ams_jvm_memory_heap_committed gauge
amoro_ams_jvm_memory_heap_committed 8.5983232E9
# HELP amoro_ams_jvm_cpu_time The CPU time used by the AMS
# TYPE amoro_ams_jvm_cpu_time gauge
amoro_ams_jvm_cpu_time 3.44E9
# HELP amoro_ams_jvm_threads_count The total number of live threads used by the AMS
```

## Documentation

It can be documented on how to scrape prometheus metrics, and import already existing Grafana Dashboard at `grafana/dashboard.json` path of the repository.