### PR TITLE
feat: plan fail as process fail

### DIFF
--- a/amoro-ams/src/main/java/org/apache/amoro/server/optimizing/OptimizingQueue.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/optimizing/OptimizingQueue.java
@@ -137,7 +137,7 @@ public class OptimizingQueue extends PersistentBase {
           "Found orphaned PLANNING status for table {} on startup; marking process failed for re-scheduling.",
           tableRuntime.getTableIdentifier());
       tableRuntime.planFailed(
-          "orphaned PLANNING on AMS startup; process marked failed for re-schedule");
+          "orphaned PLANNING on AMS startup; process marked failed for re-schedule", null);
     }
 
     TableOptimizingProcess process = null;
@@ -346,7 +346,8 @@ public class OptimizingQueue extends PersistentBase {
               tableRuntime.refresh(table),
               (MixedTable) table.originalTable(),
               getAvailableCore(),
-              maxInputSizePerThread());
+              maxInputSizePerThread(),
+              tableRuntime.getProcessId());
       if (planner.isNecessary()) {
         return new TableOptimizingProcess(planner, tableRuntime);
       } else {
@@ -856,6 +857,14 @@ public class OptimizingQueue extends PersistentBase {
                           "",
                           new HashMap<>(),
                           getSummary().summaryAsMap(false))),
+          () ->
+              doAs(
+                  TableProcessMapper.class,
+                  mapper ->
+                      mapper.updateProcessType(
+                          tableRuntime.getTableIdentifier().getId(),
+                          processId,
+                          optimizingType.name().toUpperCase())),
           () ->
               doAs(
                   OptimizingProcessMapper.class,

--- a/amoro-ams/src/main/java/org/apache/amoro/server/optimizing/OptimizingQueue.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/optimizing/OptimizingQueue.java
@@ -57,7 +57,6 @@ import org.apache.amoro.shade.guava32.com.google.common.annotations.VisibleForTe
 import org.apache.amoro.shade.guava32.com.google.common.base.Preconditions;
 import org.apache.amoro.shade.guava32.com.google.common.collect.Lists;
 import org.apache.amoro.shade.guava32.com.google.common.collect.Maps;
-import org.apache.amoro.shade.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.amoro.table.MixedTable;
 import org.apache.amoro.table.TableIdentifier;
 import org.apache.amoro.utils.CompatiblePropertyUtil;
@@ -70,16 +69,8 @@ import org.apache.iceberg.util.StructLikeMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.nio.file.StandardOpenOption;
-import java.time.Instant;
-import java.time.ZoneOffset;
-import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -140,12 +131,13 @@ public class OptimizingQueue extends PersistentBase {
   }
 
   private void initTableRuntime(DefaultTableRuntime tableRuntime) {
-    // Recover tables stranded in PLANNING to PENDING
+    // Recover tables stranded in PLANNING: mark process FAILED then IDLE for re-scheduling
     if (tableRuntime.getOptimizingStatus() == OptimizingStatus.PLANNING) {
       LOG.warn(
-          "Found orphaned PLANNING status for table {} on startup; resetting to PENDING status for re-scheduling.",
+          "Found orphaned PLANNING status for table {} on startup; marking process failed for re-scheduling.",
           tableRuntime.getTableIdentifier());
-      tableRuntime.planFailed();
+      tableRuntime.planFailed(
+          "orphaned PLANNING on AMS startup; process marked failed for re-schedule");
     }
 
     TableOptimizingProcess process = null;
@@ -348,7 +340,6 @@ public class OptimizingQueue extends PersistentBase {
     tableRuntime.beginPlanning();
     try {
       ServerTableIdentifier identifier = tableRuntime.getTableIdentifier();
-      // mostly here corrupted metadata reacts:
       AmoroTable<?> table = catalogManager.loadTable(identifier.getIdentifier());
       AbstractOptimizingPlanner planner =
           IcebergTableUtil.createOptimizingPlanner(
@@ -363,7 +354,7 @@ public class OptimizingQueue extends PersistentBase {
         return null;
       }
     } catch (Throwable throwable) {
-      tableRuntime.planFailed();
+      tableRuntime.planFailed(ExceptionUtil.getErrorMessage(throwable, 4000), throwable);
       LOG.error("Planning table {} failed", tableRuntime.getTableIdentifier(), throwable);
       throw throwable;
     }
@@ -854,16 +845,15 @@ public class OptimizingQueue extends PersistentBase {
               doAs(
                   TableProcessMapper.class,
                   mapper ->
-                      mapper.insertProcess(
+                      mapper.updateProcess(
                           tableRuntime.getTableIdentifier().getId(),
                           processId,
                           "",
                           status,
-                          optimizingType.name().toUpperCase(),
                           tableRuntime.getOptimizingStatus().name().toLowerCase(),
-                          "AMORO",
                           0,
-                          planTime,
+                          0L,
+                          "",
                           new HashMap<>(),
                           getSummary().summaryAsMap(false))),
           () ->
@@ -910,7 +900,7 @@ public class OptimizingQueue extends PersistentBase {
           () -> tableRuntime.completeProcess(success),
           () -> clearProcess(this));
       if (!success && failedReason != null) {
-        appendFailReasonToDriverLogs(failedReason, processId);
+        tableRuntime.appendFailReasonToDriverLogs(failedReason, processId);
       }
     }
 
@@ -962,33 +952,6 @@ public class OptimizingQueue extends PersistentBase {
         taskRuntime.getCompletedFuture().whenCompleted(() -> acceptResult(taskRuntime));
         taskMap.put(taskRuntime.getTaskId(), taskRuntime);
         taskQueue.offer(taskRuntime);
-      }
-    }
-
-    private void appendFailReasonToDriverLogs(String failedReason, long processId) {
-      String envLogDir = System.getenv("LOG_DIR");
-      String logBaseDir =
-          (envLogDir != null && !envLogDir.isEmpty()) ? envLogDir : "/mnt/amoro-logs/compaction";
-      Path driverLogPath = Paths.get(logBaseDir, String.valueOf(processId), "driver.log");
-      String time =
-          DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS")
-              .withZone(ZoneOffset.UTC)
-              .format(Instant.now());
-      try {
-        Files.createDirectories(driverLogPath.getParent());
-        Map<String, String> logEntry = new LinkedHashMap<>();
-        logEntry.put("level", "ERROR");
-        logEntry.put("time", time);
-        logEntry.put("processId", String.valueOf(processId));
-        logEntry.put("taskId", "");
-        logEntry.put("logger", "");
-        logEntry.put("message", failedReason);
-        logEntry.put("stackTrace", "");
-        String logLine = new ObjectMapper().writeValueAsString(logEntry) + System.lineSeparator();
-        Files.writeString(
-            driverLogPath, logLine, StandardOpenOption.CREATE, StandardOpenOption.APPEND);
-      } catch (Exception e) {
-        LOG.warn("Failed to append fail reason to driver log for process {}", processId, e);
       }
     }
   }

--- a/amoro-ams/src/main/java/org/apache/amoro/server/optimizing/OptimizingQueue.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/optimizing/OptimizingQueue.java
@@ -909,7 +909,7 @@ public class OptimizingQueue extends PersistentBase {
           () -> tableRuntime.completeProcess(success),
           () -> clearProcess(this));
       if (!success && failedReason != null) {
-        tableRuntime.appendFailReasonToDriverLogs(failedReason, processId);
+        tableRuntime.appendDriverLogEntry(processId, "ERROR", failedReason, null);
       }
     }
 

--- a/amoro-ams/src/main/java/org/apache/amoro/server/persistence/mapper/TableProcessMapper.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/persistence/mapper/TableProcessMapper.java
@@ -14,6 +14,8 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
+ * Modified by Datazip Inc. in 2026
  */
 
 package org.apache.amoro.server.persistence.mapper;
@@ -85,6 +87,13 @@ public interface TableProcessMapper {
       @Param("failMessage") String failMessage,
       @Param("processParameters") Map<String, String> processParameters,
       @Param("summary") Map<String, String> summary);
+
+  @Update(
+      "UPDATE table_process SET process_type = #{processType} WHERE process_id = #{processId} AND table_id = #{tableId}")
+  void updateProcessType(
+      @Param("tableId") long tableId,
+      @Param("processId") long processId,
+      @Param("processType") String processType);
 
   @Select(
       "SELECT process_id, table_id, external_process_identifier, status, process_type, process_stage, execution_engine, retry_number, "

--- a/amoro-ams/src/main/java/org/apache/amoro/server/scheduler/inline/TableRuntimeRefreshExecutor.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/scheduler/inline/TableRuntimeRefreshExecutor.java
@@ -111,7 +111,6 @@ public class TableRuntimeRefreshExecutor extends PeriodicTableScheduler {
       defaultTableRuntime.refresh(table);
 
       MixedTable mixedTable = (MixedTable) table.originalTable();
-      // first, evaluate cron then update healthscore
       evaluateCronTriggers(defaultTableRuntime, mixedTable);
     } catch (Throwable throwable) {
       logger.error("Refreshing table {} failed.", tableRuntime.getTableIdentifier(), throwable);

--- a/amoro-ams/src/main/java/org/apache/amoro/server/scheduler/inline/TableRuntimeRefreshExecutor.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/scheduler/inline/TableRuntimeRefreshExecutor.java
@@ -113,7 +113,6 @@ public class TableRuntimeRefreshExecutor extends PeriodicTableScheduler {
       MixedTable mixedTable = (MixedTable) table.originalTable();
       // first, evaluate cron then update healthscore
       evaluateCronTriggers(defaultTableRuntime, mixedTable);
-      updateHealthScore(defaultTableRuntime, mixedTable);
     } catch (Throwable throwable) {
       logger.error("Refreshing table {} failed.", tableRuntime.getTableIdentifier(), throwable);
     }

--- a/amoro-ams/src/main/java/org/apache/amoro/server/table/DefaultTableRuntime.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/table/DefaultTableRuntime.java
@@ -64,15 +64,15 @@ import org.apache.iceberg.Snapshot;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.nio.file.Files;
+import java.util.HashMap;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.nio.file.StandardOpenOption;
-import java.time.Instant;
-import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
-import java.util.HashMap;
+import java.time.ZoneOffset;
+import java.time.Instant;
 import java.util.LinkedHashMap;
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -90,10 +90,8 @@ public class DefaultTableRuntime extends AbstractTableRuntime
 
   private static final SnowflakeIdGenerator ID_GENERATOR = new SnowflakeIdGenerator();
 
-  /** Matches {@code %c{1}} of the optimizer's JSON_LOG_PATTERN for driver-side entries. */
   private static final String DRIVER_LOG_LOGGER = "OptimizingQueue";
 
-  /** Same instant format as the optimizer's routing appender, so the UI parses both alike. */
   private static final DateTimeFormatter DRIVER_LOG_TIME_FORMATTER =
       DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").withZone(ZoneOffset.UTC);
 
@@ -383,8 +381,7 @@ public class DefaultTableRuntime extends AbstractTableRuntime
   public long beginPlanning() {
     long processId = ID_GENERATOR.generateId();
     long now = System.currentTimeMillis();
-    OptimizingType type =
-        pendingCronType != null ? pendingCronType : OptimizingType.MINOR; // needed?
+    OptimizingType type = pendingCronType != null ? pendingCronType : OptimizingType.MINOR;
     Map<String, String> summary = new HashMap<>();
     summary.put("optimizingType", type.name());
     summary.put("phase", "PLANNING");
@@ -411,8 +408,6 @@ public class DefaultTableRuntime extends AbstractTableRuntime
         .updateState(PROCESS_ID_KEY, any -> processId)
         .commit();
 
-    appendDriverLogEntry(
-        processId, "INFO", String.format("Begin planning %s optimizing", type.name()), null);
     return processId;
   }
 
@@ -556,8 +551,7 @@ public class DefaultTableRuntime extends AbstractTableRuntime
   private void finalizePlanningProcess(
       long processId, ProcessStatus status, String reason, Throwable throwable) {
     long now = System.currentTimeMillis();
-    OptimizingType type =
-        pendingCronType != null ? pendingCronType : OptimizingType.MINOR; // needed?
+    OptimizingType type = pendingCronType != null ? pendingCronType : OptimizingType.MINOR;
     Map<String, String> summary = new HashMap<>();
     summary.put("optimizingType", type.name());
     if (status == ProcessStatus.SKIPPED) {
@@ -577,8 +571,7 @@ public class DefaultTableRuntime extends AbstractTableRuntime
                 reason,
                 new HashMap<>(),
                 summary));
-    // Only FAILED writes a log entry: a SKIPPED tick must not create <processId>/driver.log,
-    // otherwise the logs API reports an existing but near-empty log for every empty plan.
+
     if (status == ProcessStatus.FAILED) {
       appendDriverLogEntry(processId, "ERROR", describeThrowable(throwable, reason), throwable);
     }
@@ -588,12 +581,6 @@ public class DefaultTableRuntime extends AbstractTableRuntime
     appendDriverLogEntry(processId, "ERROR", failedReason, null);
   }
 
-  /**
-   * Appends a single NDJSON entry to {@code <LOG_DIR>/<processId>/driver.log}, the same file the
-   * optimizer's routing appender writes and {@code LogController} reads. Key order and names mirror
-   * JSON_LOG_PATTERN of {@code conf/optimize/log4j2-routing.xml} so consumers cannot tell an
-   * AMS-written entry from an optimizer-written one.
-   */
   private void appendDriverLogEntry(
       long processId, String level, String message, Throwable throwable) {
     String envLogDir = System.getenv("LOG_DIR");
@@ -629,6 +616,7 @@ public class DefaultTableRuntime extends AbstractTableRuntime
         ? throwable.getClass().getName()
         : throwable.getClass().getName() + ": " + message;
   }
+
 
   public void optimizingNotNecessary() {
     if (getOptimizingStatus() == OptimizingStatus.IDLE) {

--- a/amoro-ams/src/main/java/org/apache/amoro/server/table/DefaultTableRuntime.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/table/DefaultTableRuntime.java
@@ -90,8 +90,6 @@ public class DefaultTableRuntime extends AbstractTableRuntime
 
   private static final SnowflakeIdGenerator ID_GENERATOR = new SnowflakeIdGenerator();
 
-  private static final String DRIVER_LOG_LOGGER = "OptimizingQueue";
-
   private static final DateTimeFormatter DRIVER_LOG_TIME_FORMATTER =
       DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").withZone(ZoneOffset.UTC);
 
@@ -378,14 +376,16 @@ public class DefaultTableRuntime extends AbstractTableRuntime
     return this;
   }
 
-  public long beginPlanning() {
+  private String triggeredTypeName() {
+    OptimizingType cronType = this.pendingCronType;
+    return cronType == null ? "UNKNOWN" : cronType.name();
+  }
+
+  public void beginPlanning() {
     long processId = ID_GENERATOR.generateId();
     long now = System.currentTimeMillis();
-    OptimizingType type = pendingCronType != null ? pendingCronType : OptimizingType.MINOR;
     Map<String, String> summary = new HashMap<>();
-    summary.put("optimizingType", type.name());
-    summary.put("phase", "PLANNING");
-
+    summary.put("optimizingType", triggeredTypeName());
     doAs(
         TableProcessMapper.class,
         mapper ->
@@ -394,7 +394,7 @@ public class DefaultTableRuntime extends AbstractTableRuntime
                 processId,
                 "",
                 ProcessStatus.RUNNING,
-                type.name().toUpperCase(),
+                triggeredTypeName().toUpperCase(),
                 OptimizingStatus.PLANNING.name().toLowerCase(),
                 "AMORO",
                 0,
@@ -407,19 +407,10 @@ public class DefaultTableRuntime extends AbstractTableRuntime
         .updateStatusCode(code -> OptimizingStatus.PLANNING.getCode())
         .updateState(PROCESS_ID_KEY, any -> processId)
         .commit();
-
-    return processId;
-  }
-
-  public void planFailed(String reason) {
-    planFailed(reason, null);
   }
 
   public void planFailed(String reason, Throwable throwable) {
-    long processId = getProcessId();
-    if (processId != 0) {
-      finalizePlanningProcess(processId, ProcessStatus.FAILED, reason, throwable);
-    }
+    finalizePlanningProcess(ProcessStatus.FAILED, reason, throwable);
 
     store()
         .begin()
@@ -526,18 +517,13 @@ public class DefaultTableRuntime extends AbstractTableRuntime
       return;
     }
 
-    OptimizingType cronType = this.pendingCronType;
     String reason =
         String.format(
             "cron fired for %s but planner evaluated and found no data to process",
-            cronType != null ? cronType : "UNKNOWN");
+            triggeredTypeName());
 
-    long processId = getProcessId();
-    if (processId != 0) {
-      finalizePlanningProcess(processId, ProcessStatus.SKIPPED, reason, null);
-    } else if (cronType != null) {
-      recordSkippedOptimization(cronType, reason);
-    }
+    finalizePlanningProcess(ProcessStatus.SKIPPED, reason, null);
+    recordSkippedOptimization(this.pendingCronType, reason);
 
     store()
         .begin()
@@ -548,29 +534,42 @@ public class DefaultTableRuntime extends AbstractTableRuntime
     this.pendingCronType = null;
   }
 
-  private void finalizePlanningProcess(
-      long processId, ProcessStatus status, String reason, Throwable throwable) {
+  private void finalizePlanningProcess(ProcessStatus status, String reason, Throwable throwable) {
+
+    long processId = getProcessId();
+    if (getOptimizingStatus() != OptimizingStatus.PLANNING || processId == 0) {
+      return;
+    }
+
     long now = System.currentTimeMillis();
-    OptimizingType type = pendingCronType != null ? pendingCronType : OptimizingType.MINOR;
     Map<String, String> summary = new HashMap<>();
-    summary.put("optimizingType", type.name());
+    summary.put("optimizingType", triggeredTypeName());
     if (status == ProcessStatus.SKIPPED) {
       summary.put("skipReason", reason);
     }
-    doAs(
-        TableProcessMapper.class,
-        mapper ->
-            mapper.updateProcess(
-                getTableIdentifier().getId(),
-                processId,
-                "",
-                status,
-                status.name().toLowerCase(),
-                0,
-                now,
-                reason,
-                new HashMap<>(),
-                summary));
+
+    try {
+      doAs(
+          TableProcessMapper.class,
+          mapper ->
+              mapper.updateProcess(
+                  getTableIdentifier().getId(),
+                  processId,
+                  "",
+                  status,
+                  status.name().toLowerCase(),
+                  0,
+                  now,
+                  reason,
+                  new HashMap<>(),
+                  summary));
+    } catch (Exception e) {
+      LOG.warn(
+          "Failed to finalize planning process for table {} and process id {}",
+          getTableIdentifier(),
+          processId,
+          e);
+    }
 
     if (status == ProcessStatus.FAILED) {
       appendDriverLogEntry(processId, "ERROR", describeThrowable(throwable, reason), throwable);
@@ -594,7 +593,7 @@ public class DefaultTableRuntime extends AbstractTableRuntime
       logEntry.put("time", DRIVER_LOG_TIME_FORMATTER.format(Instant.now()));
       logEntry.put("processId", String.valueOf(processId));
       logEntry.put("taskId", "");
-      logEntry.put("logger", DRIVER_LOG_LOGGER);
+      logEntry.put("logger", "");
       logEntry.put("message", message);
       logEntry.put(
           "stackTrace",

--- a/amoro-ams/src/main/java/org/apache/amoro/server/table/DefaultTableRuntime.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/table/DefaultTableRuntime.java
@@ -576,11 +576,7 @@ public class DefaultTableRuntime extends AbstractTableRuntime
     }
   }
 
-  public void appendFailReasonToDriverLogs(String failedReason, long processId) {
-    appendDriverLogEntry(processId, "ERROR", failedReason, null);
-  }
-
-  private void appendDriverLogEntry(
+  public void appendDriverLogEntry(
       long processId, String level, String message, Throwable throwable) {
     String envLogDir = System.getenv("LOG_DIR");
     String logBaseDir =

--- a/amoro-ams/src/main/java/org/apache/amoro/server/table/DefaultTableRuntime.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/table/DefaultTableRuntime.java
@@ -384,8 +384,9 @@ public class DefaultTableRuntime extends AbstractTableRuntime
   public void beginPlanning() {
     long processId = ID_GENERATOR.generateId();
     long now = System.currentTimeMillis();
+    String optimizingTypeName = triggeredTypeName();
     Map<String, String> summary = new HashMap<>();
-    summary.put("optimizingType", triggeredTypeName());
+    summary.put("optimizingType", optimizingTypeName);
     doAs(
         TableProcessMapper.class,
         mapper ->
@@ -394,7 +395,7 @@ public class DefaultTableRuntime extends AbstractTableRuntime
                 processId,
                 "",
                 ProcessStatus.RUNNING,
-                triggeredTypeName().toUpperCase(),
+                optimizingTypeName.toUpperCase(),
                 OptimizingStatus.PLANNING.name().toLowerCase(),
                 "AMORO",
                 0,
@@ -523,7 +524,6 @@ public class DefaultTableRuntime extends AbstractTableRuntime
             triggeredTypeName());
 
     finalizePlanningProcess(ProcessStatus.SKIPPED, reason, null);
-    recordSkippedOptimization(this.pendingCronType, reason);
 
     store()
         .begin()

--- a/amoro-ams/src/main/java/org/apache/amoro/server/table/DefaultTableRuntime.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/table/DefaultTableRuntime.java
@@ -51,6 +51,7 @@ import org.apache.amoro.server.table.cleanup.TableRuntimeCleanupState;
 import org.apache.amoro.server.utils.IcebergTableUtil;
 import org.apache.amoro.server.utils.SnowflakeIdGenerator;
 import org.apache.amoro.shade.guava32.com.google.common.collect.Lists;
+import org.apache.amoro.shade.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.amoro.shade.zookeeper3.org.apache.curator.shaded.com.google.common.collect.Maps;
 import org.apache.amoro.table.BaseTable;
 import org.apache.amoro.table.ChangeTable;
@@ -58,10 +59,20 @@ import org.apache.amoro.table.MixedTable;
 import org.apache.amoro.table.StateKey;
 import org.apache.amoro.table.TableRuntimeStore;
 import org.apache.amoro.table.UnkeyedTable;
+import org.apache.amoro.utils.ExceptionUtil;
 import org.apache.iceberg.Snapshot;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -78,6 +89,13 @@ public class DefaultTableRuntime extends AbstractTableRuntime
   private static final Logger LOG = LoggerFactory.getLogger(DefaultTableRuntime.class);
 
   private static final SnowflakeIdGenerator ID_GENERATOR = new SnowflakeIdGenerator();
+
+  /** Matches {@code %c{1}} of the optimizer's JSON_LOG_PATTERN for driver-side entries. */
+  private static final String DRIVER_LOG_LOGGER = "OptimizingQueue";
+
+  /** Same instant format as the optimizer's routing appender, so the UI parses both alike. */
+  private static final DateTimeFormatter DRIVER_LOG_TIME_FORMATTER =
+      DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").withZone(ZoneOffset.UTC);
 
   private static final StateKey<TableRuntimeOptimizingState> OPTIMIZING_STATE_KEY =
       StateKey.stateKey("optimizing_state")
@@ -362,18 +380,61 @@ public class DefaultTableRuntime extends AbstractTableRuntime
     return this;
   }
 
-  public void beginPlanning() {
-    OptimizingStatus originalStatus = getOptimizingStatus();
-    store().begin().updateStatusCode(code -> OptimizingStatus.PLANNING.getCode()).commit();
+  public long beginPlanning() {
+    long processId = ID_GENERATOR.generateId();
+    long now = System.currentTimeMillis();
+    OptimizingType type =
+        pendingCronType != null ? pendingCronType : OptimizingType.MINOR; // needed?
+    Map<String, String> summary = new HashMap<>();
+    summary.put("optimizingType", type.name());
+    summary.put("phase", "PLANNING");
+
+    doAs(
+        TableProcessMapper.class,
+        mapper ->
+            mapper.insertProcess(
+                getTableIdentifier().getId(),
+                processId,
+                "",
+                ProcessStatus.RUNNING,
+                type.name().toUpperCase(),
+                OptimizingStatus.PLANNING.name().toLowerCase(),
+                "AMORO",
+                0,
+                now,
+                new HashMap<>(),
+                summary));
+
+    store()
+        .begin()
+        .updateStatusCode(code -> OptimizingStatus.PLANNING.getCode())
+        .updateState(PROCESS_ID_KEY, any -> processId)
+        .commit();
+
+    appendDriverLogEntry(
+        processId, "INFO", String.format("Begin planning %s optimizing", type.name()), null);
+    return processId;
   }
 
-  public void planFailed() {
-    OptimizingStatus originalStatus = getOptimizingStatus();
-    store().begin().updateStatusCode(code -> OptimizingStatus.IDLE.getCode()).commit();
+  public void planFailed(String reason) {
+    planFailed(reason, null);
+  }
+
+  public void planFailed(String reason, Throwable throwable) {
+    long processId = getProcessId();
+    if (processId != 0) {
+      finalizePlanningProcess(processId, ProcessStatus.FAILED, reason, throwable);
+    }
+
+    store()
+        .begin()
+        .updateStatusCode(code -> OptimizingStatus.IDLE.getCode())
+        .updateState(PROCESS_ID_KEY, any -> 0L)
+        .commit();
+    this.pendingCronType = null;
   }
 
   public void beginProcess(OptimizingProcess optimizingProcess) {
-    OptimizingStatus originalStatus = getOptimizingStatus();
     this.optimizingProcess = optimizingProcess;
 
     store()
@@ -466,21 +527,107 @@ public class DefaultTableRuntime extends AbstractTableRuntime
     OptimizingStatus originalStatus = getOptimizingStatus();
     boolean needUpdate =
         originalStatus == OptimizingStatus.PLANNING || originalStatus == OptimizingStatus.PENDING;
-    if (needUpdate) {
-      OptimizingType cronType = this.pendingCronType;
-      if (cronType != null) {
-        recordSkippedOptimization(
-            cronType,
-            String.format(
-                "cron fired for %s but planner evaluated and found no data to process", cronType));
-      }
-      store()
-          .begin()
-          .updateStatusCode(code -> OptimizingStatus.IDLE.getCode())
-          .updateState(PENDING_INPUT_KEY, any -> new AbstractOptimizingEvaluator.PendingInput())
-          .commit();
-      this.pendingCronType = null;
+    if (!needUpdate) {
+      return;
     }
+
+    OptimizingType cronType = this.pendingCronType;
+    String reason =
+        String.format(
+            "cron fired for %s but planner evaluated and found no data to process",
+            cronType != null ? cronType : "UNKNOWN");
+
+    long processId = getProcessId();
+    if (processId != 0) {
+      finalizePlanningProcess(processId, ProcessStatus.SKIPPED, reason, null);
+    } else if (cronType != null) {
+      recordSkippedOptimization(cronType, reason);
+    }
+
+    store()
+        .begin()
+        .updateStatusCode(code -> OptimizingStatus.IDLE.getCode())
+        .updateState(PENDING_INPUT_KEY, any -> new AbstractOptimizingEvaluator.PendingInput())
+        .updateState(PROCESS_ID_KEY, any -> 0L)
+        .commit();
+    this.pendingCronType = null;
+  }
+
+  private void finalizePlanningProcess(
+      long processId, ProcessStatus status, String reason, Throwable throwable) {
+    long now = System.currentTimeMillis();
+    OptimizingType type =
+        pendingCronType != null ? pendingCronType : OptimizingType.MINOR; // needed?
+    Map<String, String> summary = new HashMap<>();
+    summary.put("optimizingType", type.name());
+    if (status == ProcessStatus.SKIPPED) {
+      summary.put("skipReason", reason);
+    }
+    doAs(
+        TableProcessMapper.class,
+        mapper ->
+            mapper.updateProcess(
+                getTableIdentifier().getId(),
+                processId,
+                "",
+                status,
+                status.name().toLowerCase(),
+                0,
+                now,
+                reason,
+                new HashMap<>(),
+                summary));
+    // Only FAILED writes a log entry: a SKIPPED tick must not create <processId>/driver.log,
+    // otherwise the logs API reports an existing but near-empty log for every empty plan.
+    if (status == ProcessStatus.FAILED) {
+      appendDriverLogEntry(processId, "ERROR", describeThrowable(throwable, reason), throwable);
+    }
+  }
+
+  public void appendFailReasonToDriverLogs(String failedReason, long processId) {
+    appendDriverLogEntry(processId, "ERROR", failedReason, null);
+  }
+
+  /**
+   * Appends a single NDJSON entry to {@code <LOG_DIR>/<processId>/driver.log}, the same file the
+   * optimizer's routing appender writes and {@code LogController} reads. Key order and names mirror
+   * JSON_LOG_PATTERN of {@code conf/optimize/log4j2-routing.xml} so consumers cannot tell an
+   * AMS-written entry from an optimizer-written one.
+   */
+  private void appendDriverLogEntry(
+      long processId, String level, String message, Throwable throwable) {
+    String envLogDir = System.getenv("LOG_DIR");
+    String logBaseDir =
+        (envLogDir != null && !envLogDir.isEmpty()) ? envLogDir : "/mnt/amoro-logs/compaction";
+    Path driverLogPath = Paths.get(logBaseDir, String.valueOf(processId), "driver.log");
+    try {
+      Files.createDirectories(driverLogPath.getParent());
+      Map<String, String> logEntry = new LinkedHashMap<>();
+      logEntry.put("level", level);
+      logEntry.put("time", DRIVER_LOG_TIME_FORMATTER.format(Instant.now()));
+      logEntry.put("processId", String.valueOf(processId));
+      logEntry.put("taskId", "");
+      logEntry.put("logger", DRIVER_LOG_LOGGER);
+      logEntry.put("message", message);
+      logEntry.put(
+          "stackTrace",
+          throwable == null ? "" : ExceptionUtil.getErrorMessage(throwable, Integer.MAX_VALUE));
+      String logLine = new ObjectMapper().writeValueAsString(logEntry) + System.lineSeparator();
+      Files.writeString(
+          driverLogPath, logLine, StandardOpenOption.CREATE, StandardOpenOption.APPEND);
+    } catch (Exception e) {
+      LOG.warn("Failed to append {} entry to driver log for process {}", level, processId, e);
+    }
+  }
+
+  private static String describeThrowable(Throwable throwable, String fallback) {
+    if (throwable == null) {
+      return fallback;
+    }
+    String message = throwable.getMessage();
+    return message == null
+        ? throwable.getClass().getName()
+        : throwable.getClass().getName() + ": " + message;
   }
 
   public void optimizingNotNecessary() {

--- a/amoro-ams/src/main/java/org/apache/amoro/server/table/DefaultTableRuntime.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/table/DefaultTableRuntime.java
@@ -64,15 +64,15 @@ import org.apache.iceberg.Snapshot;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.HashMap;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.time.format.DateTimeFormatter;
-import java.time.ZoneOffset;
-import java.time.Instant;
-import java.util.LinkedHashMap;
-import java.nio.file.Files;
 import java.nio.file.StandardOpenOption;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -616,7 +616,6 @@ public class DefaultTableRuntime extends AbstractTableRuntime
         ? throwable.getClass().getName()
         : throwable.getClass().getName() + ": " + message;
   }
-
 
   public void optimizingNotNecessary() {
     if (getOptimizingStatus() == OptimizingStatus.IDLE) {

--- a/amoro-ams/src/main/java/org/apache/amoro/server/utils/IcebergTableUtil.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/utils/IcebergTableUtil.java
@@ -14,7 +14,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * 
+ *
  * Modified by Datazip Inc. in 2026
  */
 

--- a/amoro-ams/src/main/java/org/apache/amoro/server/utils/IcebergTableUtil.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/utils/IcebergTableUtil.java
@@ -284,7 +284,10 @@ public class IcebergTableUtil {
                             table, entry.getKey(), entry.getValue()))
                 .reduce(Expressions::or)
                 .orElse(Expressions.alwaysTrue());
-    long processId = snowflakeIdGenerator.generateId();
+    long processId =
+        tableRuntime.getProcessId() != 0
+            ? tableRuntime.getProcessId()
+            : snowflakeIdGenerator.generateId();
     ServerTableIdentifier identifier = tableRuntime.getTableIdentifier();
     OptimizingConfig config = tableRuntime.getOptimizingConfig();
     long lastMinor = tableRuntime.getLastMinorOptimizingTime();

--- a/amoro-ams/src/main/java/org/apache/amoro/server/utils/IcebergTableUtil.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/utils/IcebergTableUtil.java
@@ -14,6 +14,8 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * 
+ * Modified by Datazip Inc. in 2026
  */
 
 package org.apache.amoro.server.utils;

--- a/amoro-ams/src/main/java/org/apache/amoro/server/utils/IcebergTableUtil.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/utils/IcebergTableUtil.java
@@ -80,7 +80,6 @@ import java.util.stream.Collectors;
 public class IcebergTableUtil {
 
   private static final Logger LOG = LoggerFactory.getLogger(IcebergTableUtil.class);
-  private static final SnowflakeIdGenerator snowflakeIdGenerator = new SnowflakeIdGenerator();
 
   public static long getSnapshotId(Table table, boolean refresh) {
     Snapshot currentSnapshot = getSnapshot(table, refresh);
@@ -275,7 +274,8 @@ public class IcebergTableUtil {
       DefaultTableRuntime tableRuntime,
       MixedTable table,
       double availableCore,
-      long maxInputSizePerThread) {
+      long maxInputSizePerThread,
+      long processId) {
     Expression partitionFilter =
         tableRuntime.getPendingInput() == null
             ? Expressions.alwaysTrue()
@@ -286,10 +286,6 @@ public class IcebergTableUtil {
                             table, entry.getKey(), entry.getValue()))
                 .reduce(Expressions::or)
                 .orElse(Expressions.alwaysTrue());
-    long processId =
-        tableRuntime.getProcessId() != 0
-            ? tableRuntime.getProcessId()
-            : snowflakeIdGenerator.generateId();
     ServerTableIdentifier identifier = tableRuntime.getTableIdentifier();
     OptimizingConfig config = tableRuntime.getOptimizingConfig();
     long lastMinor = tableRuntime.getLastMinorOptimizingTime();

--- a/amoro-ams/src/test/java/org/apache/amoro/server/optimizing/flow/CompleteOptimizingFlow.java
+++ b/amoro-ams/src/test/java/org/apache/amoro/server/optimizing/flow/CompleteOptimizingFlow.java
@@ -14,6 +14,8 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
+ * Modified by Datazip Inc. in 2026
  */
 
 package org.apache.amoro.server.optimizing.flow;
@@ -198,7 +200,8 @@ public class CompleteOptimizingFlow {
         tableRuntime,
         table,
         availableCore,
-        OptimizerProperties.MAX_INPUT_FILE_SIZE_PER_THREAD_DEFAULT);
+        OptimizerProperties.MAX_INPUT_FILE_SIZE_PER_THREAD_DEFAULT,
+        tableRuntime.getProcessId());
   }
 
   private OptimizingConfig optimizingConfig() {

--- a/amoro-ams/src/test/java/org/apache/amoro/server/optimizing/plan/TestOptimizingPlanner.java
+++ b/amoro-ams/src/test/java/org/apache/amoro/server/optimizing/plan/TestOptimizingPlanner.java
@@ -14,6 +14,8 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
+ * Modified by Datazip Inc. in 2026
  */
 
 package org.apache.amoro.server.optimizing.plan;
@@ -106,7 +108,8 @@ public class TestOptimizingPlanner extends TestOptimizingEvaluator {
         getTableRuntime(),
         getMixedTable(),
         1,
-        OptimizerProperties.MAX_INPUT_FILE_SIZE_PER_THREAD_DEFAULT);
+        OptimizerProperties.MAX_INPUT_FILE_SIZE_PER_THREAD_DEFAULT,
+        1L);
   }
 
   @Override


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://amoro.apache.org/how-to-contribute/
  2. If the PR is related to an issue in https://github.com/apache/amoro/issues, add '[AMORO-XXXX]' in your PR title, e.g., '[AMORO-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][AMORO-XXXX] Your PR title ...'.
-->

## Why are the changes needed?
Today, if the planning itself for a table fails, it logs into ams but is never shown on the olake-UI as neither fail nor skip.
This PR marks such a process as fail, as well as appends the said ams error logs to the driver.


## Brief change log
- A process is inserted in beginPlanning() itself
- Said process marked as failed in planFailed
- In case the process goes ahead to actual optimization, the process to that process_id itself is updated
- The error message is appended to the driver

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

# Documentation

<!-- REQUIRED for new features, user-facing changes, and API modifications -->

- [ ] Documentation Link: [link to README, olake.io/docs, or olake-docs]
- [x] N/A (bug fix, refactor, or test changes only)
